### PR TITLE
fix some props, please also do this for deb(razorg) READ DESCRIPTION

### DIFF
--- a/aosp_flo.mk
+++ b/aosp_flo.mk
@@ -21,11 +21,11 @@
 # Inherit from the common Open Source product configuration
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 
-PRODUCT_NAME := aosp_flo
+PRODUCT_NAME := razor
 PRODUCT_DEVICE := flo
-PRODUCT_BRAND := Android
+PRODUCT_BRAND := google
 PRODUCT_MODEL := Nexus 7
-PRODUCT_MANUFACTURER := ASUS
+PRODUCT_MANUFACTURER := asus
 PRODUCT_RESTRICT_VENDOR_FILES := false
 
 # Inherit from hardware-specific part of the product configuration


### PR DESCRIPTION
you should also set 6.0.1 build fingerprint with this patch http://rootzwiki.com/topic/15145-build-overrides-on-pure-aosp-builds/
for play store to work better

google/razor/flo:6.0.1/MOB30X/3036618:user/release-keys
google/razorg/deb:6.0.1/MOB30X/3036618:user/release-keys
